### PR TITLE
[Fix]: Made GitHub buttons mobile responsive

### DIFF
--- a/client/topmate-readme-badge/src/App.css
+++ b/client/topmate-readme-badge/src/App.css
@@ -184,3 +184,9 @@
     align-items: center;
   }
 }
+
+@media screen and (max-width: 400px){
+  .HeaderContainerComponent {
+      flex-direction: column;
+  }
+}


### PR DESCRIPTION
This fixes issue #46 
Made the GitHub buttons in header to be mobile responsive.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/72298612/198935191-8dcac840-b290-4da0-809d-852b18d21fbc.png">
