### PR TITLE
[Fix]: Postman and Twitter icon alignment

### DIFF
--- a/client/topmate-readme-badge/src/App.css
+++ b/client/topmate-readme-badge/src/App.css
@@ -77,6 +77,11 @@
   color: #FDF2E6;
   font-weight: bold;
 }
+.button_postman, .button_twitter{
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
 .Move_Another{
   font-size: 12px;
   margin-top: 5%;

--- a/client/topmate-readme-badge/src/App.js
+++ b/client/topmate-readme-badge/src/App.js
@@ -185,45 +185,27 @@ function App() {
             <div className="button_Container">
               <div>
                 <button className="button_postman">
+                  <SiPostman />
                   <a
                     href="https://www.postman.com/restless-rocket-22186/workspace/topmate-readme-badges-api/documentation/6178851-c863d626-b2e3-49bf-82d0-4e4cb46a089c"
                     target={'_blank'}
                     rel="noreferrer"
                   >
-                    {' '}
-                    View on Postman{' '}
+                    View on Postman
                   </a>
-                  <div
-                    style={{
-                      float: 'left',
-                      marginTop: '1.5px',
-                      marginRight: '4px'
-                    }}
-                  >
-                    <SiPostman />
-                  </div>
                 </button>
               </div>
 
               <div>
                 <button className="button_twitter">
+                  <ImTwitter />
                   <a
                     href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2Fvinitshahdeo%2Ftopmate-readme-badge&via=Vinit_Shahdeo&text=Style%20your%20GitHub%20Profile%20README%20with%20an%20awesome%20Topmate%20badge&hashtags=topmate%2Creadme%2Cbadge"
                     target={'_blank'}
                     rel="noreferrer"
                   >
-                    {' '}
-                    Share on Twitter{' '}
+                    Share on Twitter
                   </a>
-                  <div
-                    style={{
-                      float: 'left',
-                      marginTop: '1.5px',
-                      marginRight: '4px'
-                    }}
-                  >
-                    <ImTwitter />
-                  </div>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
This fixes issue #45 
Center-aligned postman and Twitter icons
**Before**
<img width="415" alt="image (47)" src="https://user-images.githubusercontent.com/72298612/198942785-2530b039-f89b-44b8-9546-227ef1135bec.png">
**After**
<img width="353" alt="image" src="https://user-images.githubusercontent.com/72298612/198942919-7bd462d1-ba11-43f5-996f-94307fc1a223.png">
